### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 A Model Context Protocol server that provides package index querying capabilities. This server enables LLMs to search and retrieve information from package repositories like PyPI, npm, crates.io, Docker Hub, and Terraform Registry.
 
+<a href="https://glama.ai/mcp/servers/@oborchers/mcp-server-pacman">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@oborchers/mcp-server-pacman/badge" alt="mcp-server-pacman MCP server" />
+</a>
+
 ### Available Tools
 
 - `search_package` - Search for packages in package indices


### PR DESCRIPTION
This PR adds a badge for the [mcp-server-pacman](https://glama.ai/mcp/servers/@oborchers/mcp-server-pacman) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@oborchers/mcp-server-pacman">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@oborchers/mcp-server-pacman/badge" alt="mcp-server-pacman MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.